### PR TITLE
[draft] fix: update softbuffer to prevent pixel format crash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,7 @@ rustc-hash = "2.0"
 cctk = { git = "https://github.com/pop-os/cosmic-protocols", package = "cosmic-client-toolkit", rev = "d218c76" }
 smol = "1.0"
 smol_str = "0.2"
-softbuffer = { git = "https://github.com/pop-os/softbuffer", tag = "cosmic-4.0" }
+softbuffer = "0.4"
 syntect = "5.2"
 sysinfo = "0.30"
 thiserror = "1.0"


### PR DESCRIPTION
This fixes the issue of crashes with the error message "Visual 0xXX does not use softbuffer's pixel format":
```
thread 'main' panicked at /home/skyfall/.cargo/git/checkouts/libcosmic-b367e32ffc370f4f/43e7213/iced/tiny_skia/src/window/compositor.rs:68:10:
Create softbuffer surface for window: PlatformError(Some("Visual 0x49 does not use softbuffer's pixel format and is unsupported"), None)
```
when using the COSMIC app template. Pop!_OS' Softbuffer fork appears to be very out of date and doesn't seem to have any benefit over just using the latest softbuffer on crates.io.

(marked as draft so I can double check that everything works smoothly)